### PR TITLE
Security improvements: CSRF restore, admin verification, healthcheck hardening, Telegram settings

### DIFF
--- a/web_server/app/routes/admin.py
+++ b/web_server/app/routes/admin.py
@@ -538,9 +538,16 @@ def user_telegram_settings(user_id):
     
     if request.method == 'POST':
         telegram_id = request.form.get('telegram_id', '').strip()
-        
-        # 텔레그램 ID 업데이트
+        telegram_bot_token = request.form.get('telegram_bot_token', '').strip()
+
+        # 검증: 둘 다 있거나 둘 다 없어야 함
+        if (telegram_id and not telegram_bot_token) or (not telegram_id and telegram_bot_token):
+            flash('사용자 텔레그램 설정은 봇 토큰과 Chat ID를 모두 입력하거나 모두 비워두어야 합니다.', 'error')
+            return render_template('admin/user_telegram_settings.html', user=user)
+
+        # 빈 문자열을 None으로 변환 후 업데이트
         user.telegram_id = telegram_id if telegram_id else None
+        user.telegram_bot_token = telegram_bot_token if telegram_bot_token else None
         
         try:
             db.session.commit()

--- a/web_server/app/routes/admin.py
+++ b/web_server/app/routes/admin.py
@@ -181,7 +181,6 @@ def change_admin_password():
 @bp.route('/users/<int:user_id>/toggle-active', methods=['POST'])
 @login_required
 @admin_required
-@csrf.exempt
 def toggle_user_active(user_id):
     """사용자 활성화/비활성화 토글"""
     user = User.query.get_or_404(user_id)
@@ -208,7 +207,6 @@ def toggle_user_active(user_id):
 @bp.route('/users/<int:user_id>/toggle-admin', methods=['POST'])
 @login_required
 @admin_required
-@csrf.exempt
 def toggle_user_admin(user_id):
     """사용자 관리자 권한 토글"""
     user = User.query.get_or_404(user_id)
@@ -235,7 +233,6 @@ def toggle_user_admin(user_id):
 @bp.route('/users/<int:user_id>/approve', methods=['POST'])
 @login_required
 @admin_required
-@csrf.exempt
 def approve_user(user_id):
     """사용자 승인"""
     try:
@@ -272,7 +269,6 @@ def approve_user(user_id):
 @bp.route('/users/<int:user_id>/reject', methods=['POST'])
 @login_required
 @admin_required
-@csrf.exempt
 def reject_user(user_id):
     """사용자 가입 거부 (계정 삭제)"""
     try:
@@ -304,7 +300,6 @@ def reject_user(user_id):
 @bp.route('/users/<int:user_id>/reset-password', methods=['POST'])
 @login_required
 @admin_required
-@csrf.exempt
 def reset_user_password(user_id):
     """사용자 비밀번호 초기화"""
     try:
@@ -333,7 +328,6 @@ def reset_user_password(user_id):
 @bp.route('/users/<int:user_id>', methods=['DELETE'])
 @login_required
 @admin_required
-@csrf.exempt
 def delete_user(user_id):
     """사용자 삭제"""
     try:
@@ -416,7 +410,6 @@ def system():
 @bp.route('/system/precision-cache/clear', methods=['POST'])
 @login_required
 @admin_required
-@csrf.exempt
 def clear_precision_cache():
     """🆕 Precision 캐시 수동 정리"""
     try:
@@ -442,7 +435,6 @@ def clear_precision_cache():
 @bp.route('/system/precision-cache/warmup', methods=['POST'])
 @login_required
 @admin_required
-@csrf.exempt
 def warmup_precision_cache():
     """🆕 Precision 캐시 수동 웜업"""
     try:
@@ -513,7 +505,6 @@ def user_telegram_settings(user_id):
 @bp.route('/users/<int:user_id>/test-telegram', methods=['POST'])
 @login_required
 @admin_required
-@csrf.exempt
 def test_user_telegram(user_id):
     """관리자가 사용자의 텔레그램 연결 테스트"""
     try:
@@ -547,7 +538,6 @@ def test_user_telegram(user_id):
 @bp.route('/users/<int:user_id>/send-telegram-notification', methods=['POST'])
 @login_required
 @admin_required
-@csrf.exempt
 def send_user_telegram_notification(user_id):
     """관리자가 사용자에게 텔레그램 알림 전송"""
     try:
@@ -654,7 +644,6 @@ def telegram_settings():
 @bp.route('/system/test-global-telegram', methods=['POST'])
 @login_required
 @admin_required
-@csrf.exempt
 def test_global_telegram():
     """전역 텔레그램 설정 테스트"""
     try:

--- a/web_server/app/routes/admin.py
+++ b/web_server/app/routes/admin.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, request, flash, redirect, url_for, jsonify
+from flask import Blueprint, render_template, request, flash, redirect, url_for, jsonify, session
 from flask_login import login_required, current_user
 from functools import wraps
 from app import db, csrf
@@ -6,6 +6,7 @@ from app.models import User, Account, Strategy, StrategyAccount
 from app.services.telegram_service import telegram_service
 import secrets
 import string
+from datetime import datetime, timedelta
 
 bp = Blueprint('admin', __name__, url_prefix='/admin')
 
@@ -19,12 +20,53 @@ def admin_required(f):
         return f(*args, **kwargs)
     return decorated_function
 
+def _is_admin_session_verified() -> bool:
+    """관리자 민감 작업을 위한 추가 세션 검증 상태 확인"""
+    try:
+        verified_until_str = session.get('admin_verified_until')
+        if not verified_until_str:
+            return False
+        verified_until = datetime.fromisoformat(verified_until_str)
+        return datetime.utcnow() < verified_until
+    except Exception:
+        return False
+
+def admin_verification_required(f):
+    """민감한 관리자 작업에 대해 추가 비밀번호 검증을 요구"""
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if not _is_admin_session_verified():
+            return jsonify({
+                'success': False,
+                'require_admin_verification': True,
+                'message': '관리자 확인이 필요합니다. 비밀번호를 입력해주세요.'
+            }), 401
+        return f(*args, **kwargs)
+    return decorated
+
 @bp.route('/')
 @login_required
 @admin_required
 def index():
     """관리자 대시보드"""
     return redirect(url_for('admin.users'))
+
+@bp.route('/verify-session', methods=['POST'])
+@login_required
+@admin_required
+def verify_admin_session():
+    """관리자 비밀번호로 민감 작업 허용 세션을 일정 시간 부여"""
+    data = request.get_json() or {}
+    password = data.get('password', '')
+    if not password:
+        return jsonify({'success': False, 'message': '비밀번호를 입력해주세요.'}), 400
+    if not current_user.check_password(password):
+        return jsonify({'success': False, 'message': '비밀번호가 올바르지 않습니다.'}), 401
+
+    # 10분간 유효
+    valid_until = datetime.utcnow() + timedelta(minutes=10)
+    session['admin_verified_until'] = valid_until.isoformat()
+    return jsonify({'success': True, 'verified_until': session['admin_verified_until']})
 
 @bp.route('/users')
 @login_required
@@ -181,6 +223,7 @@ def change_admin_password():
 @bp.route('/users/<int:user_id>/toggle-active', methods=['POST'])
 @login_required
 @admin_required
+@admin_verification_required
 def toggle_user_active(user_id):
     """사용자 활성화/비활성화 토글"""
     user = User.query.get_or_404(user_id)
@@ -207,6 +250,7 @@ def toggle_user_active(user_id):
 @bp.route('/users/<int:user_id>/toggle-admin', methods=['POST'])
 @login_required
 @admin_required
+@admin_verification_required
 def toggle_user_admin(user_id):
     """사용자 관리자 권한 토글"""
     user = User.query.get_or_404(user_id)
@@ -233,6 +277,7 @@ def toggle_user_admin(user_id):
 @bp.route('/users/<int:user_id>/approve', methods=['POST'])
 @login_required
 @admin_required
+@admin_verification_required
 def approve_user(user_id):
     """사용자 승인"""
     try:
@@ -269,6 +314,7 @@ def approve_user(user_id):
 @bp.route('/users/<int:user_id>/reject', methods=['POST'])
 @login_required
 @admin_required
+@admin_verification_required
 def reject_user(user_id):
     """사용자 가입 거부 (계정 삭제)"""
     try:
@@ -300,6 +346,7 @@ def reject_user(user_id):
 @bp.route('/users/<int:user_id>/reset-password', methods=['POST'])
 @login_required
 @admin_required
+@admin_verification_required
 def reset_user_password(user_id):
     """사용자 비밀번호 초기화"""
     try:
@@ -328,6 +375,7 @@ def reset_user_password(user_id):
 @bp.route('/users/<int:user_id>', methods=['DELETE'])
 @login_required
 @admin_required
+@admin_verification_required
 def delete_user(user_id):
     """사용자 삭제"""
     try:
@@ -410,6 +458,7 @@ def system():
 @bp.route('/system/precision-cache/clear', methods=['POST'])
 @login_required
 @admin_required
+@admin_verification_required
 def clear_precision_cache():
     """🆕 Precision 캐시 수동 정리"""
     try:
@@ -435,6 +484,7 @@ def clear_precision_cache():
 @bp.route('/system/precision-cache/warmup', methods=['POST'])
 @login_required
 @admin_required
+@admin_verification_required
 def warmup_precision_cache():
     """🆕 Precision 캐시 수동 웜업"""
     try:
@@ -505,6 +555,7 @@ def user_telegram_settings(user_id):
 @bp.route('/users/<int:user_id>/test-telegram', methods=['POST'])
 @login_required
 @admin_required
+@admin_verification_required
 def test_user_telegram(user_id):
     """관리자가 사용자의 텔레그램 연결 테스트"""
     try:
@@ -538,6 +589,7 @@ def test_user_telegram(user_id):
 @bp.route('/users/<int:user_id>/send-telegram-notification', methods=['POST'])
 @login_required
 @admin_required
+@admin_verification_required
 def send_user_telegram_notification(user_id):
     """관리자가 사용자에게 텔레그램 알림 전송"""
     try:
@@ -644,6 +696,7 @@ def telegram_settings():
 @bp.route('/system/test-global-telegram', methods=['POST'])
 @login_required
 @admin_required
+@admin_verification_required
 def test_global_telegram():
     """전역 텔레그램 설정 테스트"""
     try:

--- a/web_server/app/routes/auth.py
+++ b/web_server/app/routes/auth.py
@@ -259,7 +259,6 @@ def profile():
 
 @bp.route('/profile/test-telegram', methods=['POST'])
 @login_required
-@csrf.exempt
 def test_telegram():
     """사용자의 텔레그램 연결 테스트 (사용자별 봇 토큰 지원)"""
     try:

--- a/web_server/app/routes/system.py
+++ b/web_server/app/routes/system.py
@@ -7,32 +7,21 @@ bp = Blueprint('system', __name__, url_prefix='/api')
 
 @bp.route('/system/health', methods=['GET'])
 def health_check():
-    """시스템 헬스 체크 엔드포인트"""
+    """시스템 헬스 체크 엔드포인트 - 민감한 정보 제거"""
     try:
-        # 데이터베이스 연결 확인
+        # 데이터베이스 연결만 확인
         from sqlalchemy import text
         db.session.execute(text('SELECT 1'))
-        db_status = 'healthy'
-    except Exception as e:
-        current_app.logger.error(f'데이터베이스 연결 오류: {str(e)}')
-        db_status = 'unhealthy'
-    
-    # 텔레그램 서비스 상태 확인
-    try:
-        from app.services.telegram_service import telegram_service
-        telegram_status = 'enabled' if telegram_service.is_enabled() else 'disabled'
+
+        return jsonify({
+            'status': 'healthy',
+            'timestamp': datetime.utcnow().isoformat()
+        }), 200
     except Exception:
-        telegram_status = 'error'
-    
-    return jsonify({
-        'status': 'healthy' if db_status == 'healthy' else 'unhealthy',
-        'timestamp': datetime.utcnow().isoformat(),
-        'version': '1.0.0',
-        'services': {
-            'database': db_status,
-            'telegram': telegram_status
-        }
-    })
+        return jsonify({
+            'status': 'unhealthy',
+            'timestamp': datetime.utcnow().isoformat()
+        }), 503
 
 @bp.route('/system/test-telegram', methods=['POST'])
 @login_required

--- a/web_server/app/templates/admin/user_telegram_settings.html
+++ b/web_server/app/templates/admin/user_telegram_settings.html
@@ -87,27 +87,37 @@
             </div>
             
             <div class="p-6 space-y-6">
-                <div class="form-group">
-                    <label for="telegram_id" class="block text-sm font-medium text-gray-700 mb-2">텔레그램 Chat ID</label>
-                    <div class="flex gap-2">
-                        <input type="text" id="telegram_id" name="telegram_id" 
-                               value="{{ user.telegram_id or '' }}" 
-                               class="form-input flex-1" 
-                               placeholder="예: 123456789">
-                        <button type="button" id="testTelegramBtn" 
-                                onclick="testTelegramConnection({{ user.id }})"
-                                class="btn btn-info"
-                                {% if not user.telegram_id %}disabled{% endif %}>
-                            <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-                            </svg>
-                            테스트
-                        </button>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div class="form-group">
+                        <label for="telegram_bot_token" class="block text-sm font-medium text-gray-700 mb-2">텔레그램 봇 토큰</label>
+                        <input type="password" id="telegram_bot_token" name="telegram_bot_token" 
+                               value="{{ user.telegram_bot_token or '' }}" 
+                               class="form-input" 
+                               placeholder="예: 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11">
+                        <p class="form-help">사용자별 봇 토큰을 입력하지 않으면 전역 봇 설정을 사용할 수 있습니다.</p>
                     </div>
-                    <div class="mt-2 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-md">
-                        <p class="text-sm text-blue-800 dark:text-blue-300">
-                            <strong>💡 설정 방법:</strong> 사용자에게 텔레그램에서 @userinfobot을 검색하여 대화를 시작하고, /start 명령어를 보내면 받을 수 있는 ID 숫자를 입력하도록 안내하세요.
-                        </p>
+                    <div class="form-group">
+                        <label for="telegram_id" class="block text-sm font-medium text-gray-700 mb-2">텔레그램 Chat ID</label>
+                        <div class="flex gap-2">
+                            <input type="text" id="telegram_id" name="telegram_id" 
+                                   value="{{ user.telegram_id or '' }}" 
+                                   class="form-input flex-1" 
+                                   placeholder="예: 123456789">
+                            <button type="button" id="testTelegramBtn" 
+                                    onclick="testTelegramConnection({{ user.id }})"
+                                    class="btn btn-info"
+                                    {% if not user.telegram_id and not user.telegram_bot_token %}disabled{% endif %}>
+                                <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+                                </svg>
+                                테스트
+                            </button>
+                        </div>
+                        <div class="mt-2 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-md">
+                            <p class="text-sm text-blue-800 dark:text-blue-300">
+                                <strong>💡 설정 방법:</strong> 사용자에게 텔레그램에서 @userinfobot을 검색하여 대화를 시작하고, /start 명령어를 보내면 받을 수 있는 ID 숫자를 입력하도록 안내하세요.
+                            </p>
+                        </div>
                     </div>
                 </div>
 
@@ -302,11 +312,12 @@ async function adminFetch(input, init = {}) {
 // 텔레그램 연결 테스트
 function testTelegramConnection(userId) {
     const telegramId = document.getElementById('telegram_id').value.trim();
+    const telegramBotToken = document.getElementById('telegram_bot_token').value.trim();
     const testBtn = document.getElementById('testTelegramBtn');
     const statusDiv = document.getElementById('telegramStatus');
     
-    if (!telegramId) {
-        showToast('텔레그램 ID를 먼저 입력하세요.', 'error');
+    if (!telegramId || !telegramBotToken) {
+        showToast('텔레그램 봇 토큰과 Chat ID를 모두 입력하세요.', 'error');
         return;
     }
     
@@ -408,27 +419,26 @@ function sendNotification(userId) {
     });
 }
 
-// 텔레그램 ID 입력 시 테스트 버튼 활성화/비활성화
-document.getElementById('telegram_id').addEventListener('input', function() {
+// 입력 변화 시 테스트 버튼 활성/비활성
+function updateTestButtonState() {
     const testBtn = document.getElementById('testTelegramBtn');
     const statusDiv = document.getElementById('telegramStatus');
+    const telegramId = document.getElementById('telegram_id').value.trim();
+    const telegramBotToken = document.getElementById('telegram_bot_token').value.trim();
     
-    if (this.value.trim()) {
+    if (telegramId && telegramBotToken) {
         testBtn.disabled = false;
     } else {
         testBtn.disabled = true;
         statusDiv.classList.add('hidden');
     }
-});
+}
+document.getElementById('telegram_id').addEventListener('input', updateTestButtonState);
+document.getElementById('telegram_bot_token').addEventListener('input', updateTestButtonState);
 
 // 페이지 로드 시 초기 상태 설정
 document.addEventListener('DOMContentLoaded', function() {
-    const telegramId = document.getElementById('telegram_id').value.trim();
-    const testBtn = document.getElementById('testTelegramBtn');
-    
-    if (telegramId) {
-        testBtn.disabled = false;
-    }
+    updateTestButtonState();
 });
 </script>
 {% endblock %}

--- a/web_server/app/templates/admin/user_telegram_settings.html
+++ b/web_server/app/templates/admin/user_telegram_settings.html
@@ -225,6 +225,80 @@ function getCSRFToken() {
     return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
 }
 
+// 관리자 검증 래퍼 및 모달
+let _adminVerifyResolve = null;
+function openAdminVerifyModal() {
+    const existing = document.getElementById('adminVerifyModal');
+    if (existing) existing.remove();
+    const modal = document.createElement('div');
+    modal.id = 'adminVerifyModal';
+    modal.className = 'modal-overlay';
+    modal.innerHTML = `
+    <div class="modal-content max-w-md">
+        <div class="modal-header">
+            <h3 class="text-lg font-semibold text-primary">관리자 확인</h3>
+            <button onclick="closeAdminVerifyModal()" class="modal-close">✕</button>
+        </div>
+        <div class="p-6 space-y-4">
+            <p class="text-sm text-muted">민감한 작업입니다. 관리자 비밀번호를 입력해주세요.</p>
+            <div class="form-group">
+                <label class="form-label">비밀번호</label>
+                <input id="adminVerifyPassword" type="password" class="form-input" placeholder="현재 비밀번호" />
+                <p id="adminVerifyError" class="text-sm text-red-600 mt-2 hidden"></p>
+            </div>
+            <div class="flex justify-end gap-2">
+                <button class="btn btn-secondary" onclick="closeAdminVerifyModal()">취소</button>
+                <button id="adminVerifySubmit" class="btn btn-primary" onclick="submitAdminVerification()">확인</button>
+            </div>
+        </div>
+    </div>`;
+    document.body.appendChild(modal);
+    setTimeout(() => document.getElementById('adminVerifyPassword')?.focus(), 0);
+}
+function closeAdminVerifyModal() {
+    const modal = document.getElementById('adminVerifyModal');
+    if (modal) modal.remove();
+    if (_adminVerifyResolve) { _adminVerifyResolve(false); _adminVerifyResolve = null; }
+}
+function submitAdminVerification() {
+    const password = document.getElementById('adminVerifyPassword').value;
+    const btn = document.getElementById('adminVerifySubmit');
+    const err = document.getElementById('adminVerifyError');
+    btn.disabled = true; btn.innerText = '확인 중...'; err.classList.add('hidden');
+    fetch('/admin/verify-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCSRFToken() },
+        body: JSON.stringify({ password })
+    }).then(r => r.json().then(d => ({ ok: r.ok, data: d }))).then(({ ok, data }) => {
+        if (ok && data.success) {
+            const modal = document.getElementById('adminVerifyModal');
+            if (modal) modal.remove();
+            if (_adminVerifyResolve) { _adminVerifyResolve(true); _adminVerifyResolve = null; }
+        } else {
+            err.textContent = data?.message || '검증에 실패했습니다.'; err.classList.remove('hidden');
+        }
+    }).catch(() => {
+        err.textContent = '네트워크 오류가 발생했습니다.'; err.classList.remove('hidden');
+    }).finally(() => { btn.disabled = false; btn.innerText = '확인'; });
+}
+function ensureAdminVerified() {
+    return new Promise((resolve) => { _adminVerifyResolve = resolve; openAdminVerifyModal(); });
+}
+async function adminFetch(input, init = {}) {
+    const first = await fetch(input, init);
+    if (first.status === 401 || first.status === 403) {
+        try {
+            const body = await first.clone().json();
+            if (body && body.require_admin_verification) {
+                const verified = await ensureAdminVerified();
+                if (!verified) return first;
+                return fetch(input, init);
+            }
+        } catch (_) {}
+    }
+    return first;
+}
+
 // 텔레그램 연결 테스트
 function testTelegramConnection(userId) {
     const telegramId = document.getElementById('telegram_id').value.trim();
@@ -240,7 +314,7 @@ function testTelegramConnection(userId) {
     testBtn.disabled = true;
     testBtn.innerHTML = '<div class="loading-spinner"></div>테스트 중...';
     
-    fetch(`/admin/users/${userId}/test-telegram`, {
+    adminFetch(`/admin/users/${userId}/test-telegram`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -308,7 +382,7 @@ function sendNotification(userId) {
         return;
     }
     
-    fetch(`/admin/users/${userId}/send-telegram-notification`, {
+    adminFetch(`/admin/users/${userId}/send-telegram-notification`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',

--- a/web_server/app/templates/admin/users.html
+++ b/web_server/app/templates/admin/users.html
@@ -412,6 +412,9 @@
 </div>
 
 <script>
+function getCSRFToken() {
+    return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
+}
 function showNotification(message, type = 'info') {
     const notification = document.getElementById('notification');
     const messageEl = document.getElementById('notification-message');
@@ -497,7 +500,7 @@ function approveUser(userId) {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'X-CSRFToken': document.querySelector('meta[name=csrf-token]')?.getAttribute('content') || ''
+                'X-CSRFToken': getCSRFToken()
             }
         })
         .then(response => {
@@ -531,6 +534,7 @@ function rejectUser(userId) {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
+                'X-CSRFToken': getCSRFToken()
             }
         })
         .then(response => response.json())
@@ -554,6 +558,7 @@ function toggleAdmin(userId) {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
+                'X-CSRFToken': getCSRFToken()
             }
         })
         .then(response => response.json())
@@ -584,6 +589,7 @@ function resetPassword(userId) {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
+                'X-CSRFToken': getCSRFToken()
             }
         })
         .then(response => response.json())
@@ -616,6 +622,7 @@ function deleteUser(userId) {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json',
+                'X-CSRFToken': getCSRFToken()
             }
         })
         .then(response => response.json())

--- a/web_server/app/templates/admin/users.html
+++ b/web_server/app/templates/admin/users.html
@@ -415,6 +415,85 @@
 function getCSRFToken() {
     return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
 }
+
+// 관리자 세션 검증 모달
+let _adminVerifyResolve = null;
+function openAdminVerifyModal() {
+    const existing = document.getElementById('adminVerifyModal');
+    if (existing) existing.remove();
+    const modal = document.createElement('div');
+    modal.id = 'adminVerifyModal';
+    modal.className = 'modal-overlay';
+    modal.innerHTML = `
+    <div class="modal-content max-w-md">
+        <div class="modal-header">
+            <h3 class="text-lg font-semibold text-primary">관리자 확인</h3>
+            <button onclick="closeAdminVerifyModal()" class="modal-close">✕</button>
+        </div>
+        <div class="p-6 space-y-4">
+            <p class="text-sm text-muted">민감한 작업입니다. 관리자 비밀번호를 입력해주세요.</p>
+            <div class="form-group">
+                <label class="form-label">비밀번호</label>
+                <input id="adminVerifyPassword" type="password" class="form-input" placeholder="현재 비밀번호" />
+                <p id="adminVerifyError" class="text-sm text-red-600 mt-2 hidden"></p>
+            </div>
+            <div class="flex justify-end gap-2">
+                <button class="btn btn-secondary" onclick="closeAdminVerifyModal()">취소</button>
+                <button id="adminVerifySubmit" class="btn btn-primary" onclick="submitAdminVerification()">확인</button>
+            </div>
+        </div>
+    </div>`;
+    document.body.appendChild(modal);
+    setTimeout(() => document.getElementById('adminVerifyPassword')?.focus(), 0);
+}
+function closeAdminVerifyModal() {
+    const modal = document.getElementById('adminVerifyModal');
+    if (modal) modal.remove();
+    if (_adminVerifyResolve) { _adminVerifyResolve(false); _adminVerifyResolve = null; }
+}
+function submitAdminVerification() {
+    const password = document.getElementById('adminVerifyPassword').value;
+    const btn = document.getElementById('adminVerifySubmit');
+    const err = document.getElementById('adminVerifyError');
+    btn.disabled = true; btn.innerText = '확인 중...'; err.classList.add('hidden');
+    fetch('/admin/verify-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCSRFToken() },
+        body: JSON.stringify({ password })
+    }).then(r => r.json().then(d => ({ ok: r.ok, data: d }))).then(({ ok, data }) => {
+        if (ok && data.success) {
+            const modal = document.getElementById('adminVerifyModal');
+            if (modal) modal.remove();
+            if (_adminVerifyResolve) { _adminVerifyResolve(true); _adminVerifyResolve = null; }
+        } else {
+            err.textContent = data?.message || '검증에 실패했습니다.'; err.classList.remove('hidden');
+        }
+    }).catch(() => {
+        err.textContent = '네트워크 오류가 발생했습니다.'; err.classList.remove('hidden');
+    }).finally(() => { btn.disabled = false; btn.innerText = '확인'; });
+}
+function ensureAdminVerified() {
+    return new Promise((resolve) => { _adminVerifyResolve = resolve; openAdminVerifyModal(); });
+}
+
+// 관리자 검증 자동 재시도 래퍼
+async function adminFetch(input, init = {}) {
+    const first = await fetch(input, init);
+    if (first.status === 401 || first.status === 403) {
+        try {
+            const body = await first.clone().json();
+            if (body && body.require_admin_verification) {
+                const verified = await ensureAdminVerified();
+                if (!verified) return first; // 취소 시 원 응답 반환
+                // 재시도
+                return fetch(input, init);
+            }
+        } catch (_) {
+            // 본문이 JSON이 아닐 때는 그대로 반환
+        }
+    }
+    return first;
+}
 function showNotification(message, type = 'info') {
     const notification = document.getElementById('notification');
     const messageEl = document.getElementById('notification-message');
@@ -496,7 +575,7 @@ document.addEventListener('keydown', function(e) {
 
 function approveUser(userId) {
     if (confirm('이 사용자를 승인하시겠습니까?')) {
-        fetch(`/admin/users/${userId}/approve`, {
+        adminFetch(`/admin/users/${userId}/approve`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -530,7 +609,7 @@ function approveUser(userId) {
 
 function rejectUser(userId) {
     if (confirm('이 사용자의 가입을 거부하시겠습니까? 계정이 삭제됩니다.')) {
-        fetch(`/admin/users/${userId}/reject`, {
+        adminFetch(`/admin/users/${userId}/reject`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -554,7 +633,7 @@ function rejectUser(userId) {
 
 function toggleAdmin(userId) {
     if (confirm('이 사용자의 관리자 권한을 변경하시겠습니까?')) {
-        fetch(`/admin/users/${userId}/toggle-admin`, {
+        adminFetch(`/admin/users/${userId}/toggle-admin`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -585,7 +664,7 @@ function resetPassword(userId) {
         button.disabled = true;
         button.innerHTML = '<svg class="animate-spin w-3 h-3 inline mr-1" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>처리중...';
         
-        fetch(`/admin/users/${userId}/reset-password`, {
+        adminFetch(`/admin/users/${userId}/reset-password`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -618,7 +697,7 @@ function resetPassword(userId) {
 
 function deleteUser(userId) {
     if (confirm('정말로 이 사용자를 삭제하시겠습니까? 모든 관련 데이터가 삭제됩니다.')) {
-        fetch(`/admin/users/${userId}`, {
+        adminFetch(`/admin/users/${userId}`, {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- Restore CSRF protection on admin AJAX endpoints and /auth profile telegram test
- Add short-lived admin verification requirement for sensitive admin actions (10 min)
- Harden /api/system/health to minimal status + timestamp
- Admin can now set per-user Telegram bot token and chat id; UI updated

## Changes
- routes: admin.py, auth.py, system.py
- templates: admin/users.html, admin/user_telegram_settings.html

## Test plan
- Approve/Reject/Toggle admin/Toggle active/Reset password/Delete all work with CSRF and require verification
- /auth/profile/test-telegram requires CSRF token
- /api/system/health returns only {status,timestamp}
- Admin user Telegram page accepts bot token + chat id, saves to DB, test requires both